### PR TITLE
Fix README.md and setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ source install/setup.bash
 
 Before continuing, **make sure the camera is set to dual-lens mode**
 
+Additionally, **ensure the camera's USB mode is set to Android**:
+1. On the camera, swipe down the screen to the main menu
+2. Go to Settings -> General
+3. Set USB Mode to **Android** (not Webcam or other modes)
+4. This is required for the ROS driver to properly detect and communicate with the camera (see [Issue #4](https://github.com/ai4ce/insta360_ros_driver/issues/4))
+
 The Insta360 requires sudo privilege to be accessed via USB. To compensate for this, a udev configuration can be automatically created that will only request for sudo once. The camera can thus be setup initially via:
 ```
 cd ~/ros2_ws/src/insta360_ros_driver
@@ -41,6 +47,7 @@ This creates a symlink  based on the vendor ID of Insta360 cameras. The symlink,
 **Sometimes, this does not work (e.g. you see "device /dev/insta not found" or something similar). You can try entering the commands manually, since that sometimes sees success, especially for the first time.**
 ```
 echo SUBSYSTEM=='"usb"', ATTR{manufacturer}=='"Arashi Vision"', SYMLINK+='"insta"', MODE='"0777"' | sudo tee /etc/udev/rules.d/99-insta.rules
+sudo udevadm control --reload-rules
 sudo udevadm trigger
 sudo chmod 777 /dev/insta
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -5,8 +5,9 @@
 
 #Add permissions for USB port
 # udevadm info --name /dev/bus/usb/003/026 --attribute-walk
-echo SUBSYSTEM=='"usb"', ATTR{manufacturer}=='"Arashi Vision"', SYMLINK+='"insta"', MODE='"0777"' | sudo tee /etc/udev/rules.d/99-insta.rules
-#Trigger SYMLINK creation
+echo SUBSYSTEM=='"usb"', ATTRS{idVendor}=='"2e1a"', ATTRS{idProduct}=='"00c1"', SYMLINK+='"insta"', MODE='"0777"' | sudo tee /etc/udev/rules.d/99-insta.rules
+#Reload and trigger udev rules
+sudo udevadm control --reload-rules
 sudo udevadm trigger
 
 #Grant permission for camera port

--- a/setup.sh
+++ b/setup.sh
@@ -5,10 +5,25 @@
 
 #Add permissions for USB port
 # udevadm info --name /dev/bus/usb/003/026 --attribute-walk
-echo SUBSYSTEM=='"usb"', ATTRS{idVendor}=='"2e1a"', ATTRS{idProduct}=='"00c1"', SYMLINK+='"insta"', MODE='"0777"' | sudo tee /etc/udev/rules.d/99-insta.rules
+echo SUBSYSTEM=='"usb"', ATTR{idVendor}=='"2e1a"', SYMLINK+='"insta"', MODE='"0777"' | sudo tee /etc/udev/rules.d/99-insta.rules
 #Reload and trigger udev rules
 sudo udevadm control --reload-rules
 sudo udevadm trigger
 
 #Grant permission for camera port
-sudo chmod 777 /dev/insta
+# Wait for the symlink to be created
+for i in {1..5}; do
+    if [ -e /dev/insta ]; then
+        sudo chmod 777 /dev/insta
+        echo "Successfully set permissions for /dev/insta"
+        break
+    else
+        echo "Waiting for /dev/insta to be created... (attempt $i/5)"
+        sleep 1
+    fi
+done
+
+if [ ! -e /dev/insta ]; then
+    echo "Error: /dev/insta was not created. Please check if the camera is connected and in the correct mode."
+    exit 1
+fi


### PR DESCRIPTION
## Changes
- Based on #4, added configuration instructions for Insta360 to the README.md.
- Added the command udevadm control --reload-rules to both setup.sh and README.md to ensure updated udev rules are loaded.
- Changed the usb rules matching method from relying on manufacturer to using `idVendor` and `idProduct` for device identification.


