### PR TITLE
Fix SyncLocalTimeToCamera call for latest Insta360 SDK

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,7 +121,11 @@ public:
         cam->SetStreamDelegate(delegate);
 
         auto start = time(NULL);
-        cam->SyncLocalTimeToCamera(start);        
+
+        uint64_t utc_time = static_cast<uint64_t>(start);
+        uint32_t offset_time = 0; //no offset from UTC
+
+        cam->SyncLocalTimeToCamera(utc_time,offset_time);       
         ins_camera::LiveStreamParam param;
         param.video_resolution = ins_camera::VideoResolution::RES_1920_960P30; //Change this line to edit the resolution
         //Possible resolutions (results may vary per model) are:


### PR DESCRIPTION
This PR fixes a build error caused by a mismatch between the current driver code and the latest Insta360 SDK API.

The SDK now defines:
   ` ` `bool SyncLocalTimeToCamera(uint64_t utc_time, uint32_t offset_time); ` ` `

but the driver only passed a single argument, causing a compile-time failure.

This patch:
- Passes both required arguments
- Uses the current UNIX UTC time
- Sets the offset to 0 for UTC by default
- Fully restores compatibility with the latest SDK

Tested on:
- Ubuntu 22.04
- ROS2 Humble
- Latest Insta360 SDK (downloaded on 8 dec 2025)
