### PR TITLE
Fix FFmpeg 6.0 and cv_bridge compatibility for ROS 2 Jazzy

### DIFF
--- a/include/equirectangular.hpp
+++ b/include/equirectangular.hpp
@@ -3,7 +3,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <opencv2/opencv.hpp>
 #include <memory>
 #include <mutex>

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -12,7 +12,7 @@
 #include "rclcpp/qos.hpp"
 #include "sensor_msgs/msg/compressed_image.hpp"
 #include "sensor_msgs/msg/image.hpp"
-#include "cv_bridge/cv_bridge.h"
+#include "cv_bridge/cv_bridge.hpp"
 #include "sensor_msgs/image_encodings.hpp"
 
 extern "C" {
@@ -34,7 +34,7 @@ static enum AVPixelFormat get_hw_format(AVCodecContext *ctx, const enum AVPixelF
 
 class H264DecoderNode : public rclcpp::Node {
 private:
-    AVCodec* codec_ = nullptr;
+    const AVCodec* codec_ = nullptr;
     AVCodecContext* codec_ctx_ = nullptr;
     AVCodecParserContext* parser_ctx_ = nullptr;
     AVPacket* pkt_ = nullptr;


### PR DESCRIPTION
I noticed that this driver can also work on Ubuntu 24.04 and ROS 2 Jazzy with little modifications.