### PR TITLE
adding in some notes on microsd card and optional decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ colcon build --symlink-install
 source install/setup.bash
 ```
 
-Before continuing, **make sure the camera is set to dual-lens mode**
+The Insta360 X3 (and potentially other models) needs a micro-sd card inserted to use the API. Ensure this is done.
+
+Before continuing,  **make sure the camera is set to dual-lens mode**
 
 Additionally, **ensure the camera's USB mode is set to Android**:
 1. On the camera, swipe down the screen to the main menu

--- a/launch/bringup.launch.xml
+++ b/launch/bringup.launch.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <launch>
     <arg name="equirectangular" default="false"/>
+    <arg name="decoder" default="true"/>
     <arg name="imu_filter" default="true"/>
     <arg name="equirectangular_config" default="$(find-pkg-share insta360_ros_driver)/config/equirectangular.yaml"/>
     <arg name="imu_config" default="$(find-pkg-share insta360_ros_driver)/config/imu_filter.yaml"/>
@@ -9,7 +10,7 @@
     <node pkg="insta360_ros_driver" exec="insta360_ros_driver" name="insta360_ros_driver" output="log"/>
 
     <!-- Decodes Compressed Images -->
-    <node pkg="insta360_ros_driver" exec="decoder" name="image_decoder" output="log">
+    <node pkg="insta360_ros_driver" exec="decoder" name="image_decoder" output="log" if="$(var decoder)">
         <param name="compressed_topic" value="/dual_fisheye/image/compressed"/>
         <param name="uncompressed_topic" value="/dual_fisheye/image"/>
         <!-- We can skip decoding every <skip_frame>. So skip_frame = 1 will only publish half the frames, etc. -->


### PR DESCRIPTION
I had some trouble because I didn't have a Micro-SD Card inserted. It turns out this is needed even to use the API, at least for me, so I added a note to the README on this.

I also added a parameter to make the decoder optional (to save CPU), but it is set to bring the decoder up by default so that nothing should change backwards compatibility wise...

Here's the output from running the launch file without passing any args (mainly just to show it works).
```
[INFO] [launch]: All log files can be found below /home/developer/.ros/log/2026-05-21-14-40-01-022900-student-AORUS-5-KB-12048
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [insta360_ros_driver-1]: process started with pid [12049]
[INFO] [decoder-2]: process started with pid [12051]
[INFO] [imu_filter_madgwick_node-3]: process started with pid [12053]
[imu_filter_madgwick_node-3] [INFO] [1779374401.130404537] [imu_filter]: Starting ImuFilter
[imu_filter_madgwick_node-3] [INFO] [1779374401.130586786] [imu_filter]: Using dt computed from message headers
[imu_filter_madgwick_node-3] [INFO] [1779374401.130600608] [imu_filter]: The gravity vector is kept in the IMU message.
[imu_filter_madgwick_node-3] [INFO] [1779374401.130662043] [imu_filter]: Imu filter gain set to 0.100000
[imu_filter_madgwick_node-3] [INFO] [1779374401.130680648] [imu_filter]: Gyro drift bias set to 0.000000
[imu_filter_madgwick_node-3] [INFO] [1779374401.130687754] [imu_filter]: Magnetometer bias values: 0.000000 0.000000 0.000000
[decoder-2] [INFO] [1779374401.195284962] [image_decoder]: Using hardware H.264 decoder (NVDEC)
[decoder-2] [AVHWDeviceContext @ 0x5a54021fe740] Cannot load libcuda.so.1
[decoder-2] [AVHWDeviceContext @ 0x5a54021fe740] Could not dynamically load CUDA
[decoder-2] [WARN] [1779374401.195548431] [image_decoder]: Failed to create hardware device context, falling back to software
[decoder-2] [INFO] [1779374401.195781217] [image_decoder]: H.264 Decoder Node initialized
[decoder-2] [INFO] [1779374401.195792978] [image_decoder]: Subscribing to: /dual_fisheye/image/compressed
[decoder-2] [INFO] [1779374401.195798239] [image_decoder]: Publishing to: /dual_fisheye/image
[decoder-2] [INFO] [1779374401.195802402] [image_decoder]: Skip frame: 0, I-frame only: false
[insta360_ros_driver-1] [INFO] [1779374402.035207790] [insta360_ros_driver]: Camera opened successfully.
[insta360_ros_driver-1] [INFO] [1779374402.040673781] [insta360_ros_driver]: Publisher for compressed images and IMU created.
[insta360_ros_driver-1] [INFO] [1779374405.114714492] [insta360_ros_driver]: Live streaming started.
[imu_filter_madgwick_node-3] [INFO] [1779374405.206001934] [imu_filter]: First IMU message received.
[decoder-2] [swscaler @ 0x5a5402602f00] deprecated pixel format used, make sure you did set range correctly

```